### PR TITLE
fix: import @inaccessible directive in Fed v2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,7 @@ Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: false
 Metrics/LineLength:
-  Max: 100
+  Max: 120
   Exclude:
     - lib/apollo-federation/tracing/proto/apollo_pb.rb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [3.4.0](https://github.com/Gusto/apollo-federation-ruby/compare/v3.3.1...v3.4.0) (2023-02-21)
+
+
+### Bug Fixes
+
+* address some lint violations ([#219](https://github.com/Gusto/apollo-federation-ruby/issues/219)) ([dcd11e9](https://github.com/Gusto/apollo-federation-ruby/commit/dcd11e9384f168d125d2b60941d4bff161799824))
+
+
+### Features
+
+* add support for the [@interface](https://github.com/interface)Object directive ([#218](https://github.com/Gusto/apollo-federation-ruby/issues/218)) ([c7b987d](https://github.com/Gusto/apollo-federation-ruby/commit/c7b987de1d2b32a4a77ceb09718373ffa5a60abb))
+
 ## [3.3.1](https://github.com/Gusto/apollo-federation-ruby/compare/v3.3.0...v3.3.1) (2023-01-05)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apollo-federation (3.3.1)
+    apollo-federation (3.4.0)
       google-protobuf (~> 3.21.7)
       graphql (>= 1.10.14)
 
@@ -130,4 +130,4 @@ DEPENDENCIES
   ruby-debug-ide
 
 BUNDLED WITH
-   2.4.2
+   2.4.7

--- a/gemfiles/graphql_1.10.gemfile.lock
+++ b/gemfiles/graphql_1.10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    apollo-federation (3.3.1)
+    apollo-federation (3.4.0)
       google-protobuf (~> 3.21.7)
       graphql (>= 1.10.14)
 
@@ -126,4 +126,4 @@ DEPENDENCIES
   ruby-debug-ide
 
 BUNDLED WITH
-   2.4.2
+   2.4.7

--- a/gemfiles/graphql_1.11.gemfile.lock
+++ b/gemfiles/graphql_1.11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    apollo-federation (3.3.1)
+    apollo-federation (3.4.0)
       google-protobuf (~> 3.21.7)
       graphql (>= 1.10.14)
 
@@ -126,4 +126,4 @@ DEPENDENCIES
   ruby-debug-ide
 
 BUNDLED WITH
-   2.4.2
+   2.4.7

--- a/gemfiles/graphql_1.12.gemfile.lock
+++ b/gemfiles/graphql_1.12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    apollo-federation (3.3.1)
+    apollo-federation (3.4.0)
       google-protobuf (~> 3.21.7)
       graphql (>= 1.10.14)
 
@@ -126,4 +126,4 @@ DEPENDENCIES
   ruby-debug-ide
 
 BUNDLED WITH
-   2.4.2
+   2.4.7

--- a/gemfiles/graphql_1.13.gemfile.lock
+++ b/gemfiles/graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    apollo-federation (3.3.1)
+    apollo-federation (3.4.0)
       google-protobuf (~> 3.21.7)
       graphql (>= 1.10.14)
 
@@ -125,4 +125,4 @@ DEPENDENCIES
   ruby-debug-ide
 
 BUNDLED WITH
-   2.4.2
+   2.4.7

--- a/gemfiles/graphql_2.0.gemfile.lock
+++ b/gemfiles/graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    apollo-federation (3.3.1)
+    apollo-federation (3.4.0)
       google-protobuf (~> 3.21.7)
       graphql (>= 1.10.14)
 
@@ -125,4 +125,4 @@ DEPENDENCIES
   ruby-debug-ide
 
 BUNDLED WITH
-   2.4.2
+   2.4.7

--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -14,6 +14,7 @@ module ApolloFederation
       '_entities',
       '_service',
     ].freeze
+    INACCESSIBLE_DIRECTIVE = 'inaccessible'
 
     def build_object_type_node(object_type)
       object_node = super
@@ -70,7 +71,7 @@ module ApolloFederation
     end
 
     def directive_name(directive)
-      if schema.federation_2?
+      if schema.federation_2? && directive[:name] != INACCESSIBLE_DIRECTIVE
         "#{schema.link_namespace}__#{directive[:name]}"
       else
         directive[:name]

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -61,7 +61,7 @@ module ApolloFederation
 
         <<~SCHEMA
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace})
+            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: ["@inaccessible"])
 
         SCHEMA
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -12,7 +12,7 @@ module ApolloFederation
     end
 
     module CommonMethods
-      DEFAULT_LINK_NAMESPACE = 'federation'.freeze
+      DEFAULT_LINK_NAMESPACE = 'federation'
 
       def federation(version: '1.0', link: {})
         @federation_version = version

--- a/lib/apollo-federation/version.rb
+++ b/lib/apollo-federation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ApolloFederation
-  VERSION = '3.3.1'
+  VERSION = '3.4.0'
 end

--- a/spec/apollo-federation/schema_spec.rb
+++ b/spec/apollo-federation/schema_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApolloFederation::Schema do
       expect(schema.federation_version).to eq('1.0')
     end
 
-    it 'returns the specified version when set' do
+    it 'returns the specified version when set to 2.0' do
       schema = Class.new(GraphQL::Schema) do
         include ApolloFederation::Schema
         federation version: '2.0'
@@ -23,7 +23,7 @@ RSpec.describe ApolloFederation::Schema do
       expect(schema.federation_version).to eq('2.0')
     end
 
-    it 'returns the specified version when set' do
+    it 'returns the specified version when set to 2.3' do
       schema = Class.new(GraphQL::Schema) do
         include ApolloFederation::Schema
         federation version: '2.3'
@@ -88,7 +88,7 @@ RSpec.describe ApolloFederation::Schema do
       expect(schema.federation_2?).to be(true)
     end
 
-    it 'returns true when the version is a string greater than 2.0' do
+    it 'returns true when the version is a string equal to 2.3' do
       schema = Class.new(GraphQL::Schema) do
         include ApolloFederation::Schema
         federation version: '2.3'

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product {
             upc: String!
@@ -144,7 +144,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends {
             upc: String!
@@ -180,7 +180,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Position @federation__shareable {
             x: Int!
@@ -217,9 +217,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
-          type Position @federation__inaccessible {
+          type Position @inaccessible {
             x: Int!
             y: Int!
           }
@@ -254,7 +254,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Product @fed2__extends {
               upc: String!
@@ -290,7 +290,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Position @fed2__shareable {
               x: Int!
@@ -327,9 +327,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
-            type Position @fed2__inaccessible {
+            type Position @inaccessible {
               x: Int!
               y: Int!
             }
@@ -363,7 +363,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Product @fed2__key(fields: "upc") {
               upc: String!
@@ -394,7 +394,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Product @fed2__extends @fed2__key(fields: "upc") {
               price: Int
@@ -421,7 +421,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Product @fed2__interfaceObject @fed2__key(fields: "id") {
               id: ID!
@@ -470,13 +470,13 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Book implements Product {
             upc: String!
           }
 
-          interface Product @federation__inaccessible {
+          interface Product @inaccessible {
             upc: String!
           }
         GRAPHQL
@@ -533,7 +533,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Book implements Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external
@@ -573,7 +573,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
             type Product @federation__key(fields: "upc") {
               upc: String!
@@ -604,7 +604,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
             type Product @federation__key(fields: "upc") {
               upc: String!
@@ -632,7 +632,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__key(fields: "upc") @federation__key(fields: "name") {
             name: String
@@ -660,7 +660,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
@@ -687,7 +687,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__interfaceObject @federation__key(fields: "id") {
             id: ID!
@@ -718,7 +718,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Position {
             x: Int! @federation__shareable
@@ -754,10 +754,10 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Position {
-            x: Int! @federation__inaccessible
+            x: Int! @inaccessible
             y: Int!
           }
 
@@ -786,7 +786,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "id") {
             id: ID!
@@ -822,7 +822,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
@@ -857,7 +857,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int @federation__external
@@ -886,7 +886,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
             type Product @federation__key(fields: "productId") {
               productId: String!
@@ -914,7 +914,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
             type Product @federation__extends @federation__key(fields: "product_id") {
               options: [String!]! @federation__requires(fields: "my_id")
@@ -947,7 +947,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external


### PR DESCRIPTION
### Description

Currently, due to different namespaces across multiple subgraphs, we are getting the following error:

```GraphQL
LINK_IMPORT_NAME_MISMATCH: The federation "@inaccessible" directive is imported with mismatched name between subgraphs: it is imported as "@federation__inaccessible" in subgraphs "A" and "B" but "@inaccessible" in subgraphs "C", "D"...
```

According to [prasek](https://github.com/prasek)'s comment [here](https://github.com/apollographql/federation/issues/1976#issuecomment-1184522540), we should always import the `@inaccessible` directive to avoid multiple namespaces. This PR address this.